### PR TITLE
Ending with an error shouldn't fail the resulting promise.

### DIFF
--- a/src/test/test-Stream.ts
+++ b/src/test/test-Stream.ts
@@ -491,7 +491,7 @@ describe("Stream", () => {
 			const we = track(s.end(boomError));
 			await settle([res.promise, we.promise]);
 			expect(results).to.deep.equal([1, 2]);
-			expect(we.reason).to.equal(boomError);
+			expect(we.reason).to.equal(undefined);
 			expect(res.reason).to.equal(boomError);
 		});
 

--- a/src/test/test-Stream.ts
+++ b/src/test/test-Stream.ts
@@ -1116,6 +1116,18 @@ describe("Stream", () => {
 			await settle([result.promise]);
 			expect(result.reason).to.deep.equal(boomError);
 		});
+
+		it("returns end error on abort", async () => {
+			const stream = new Stream<number>();
+			setImmediate(() => stream.end(new Error("ending the stream")));
+			try {
+				await stream.toArray();
+			} catch (e) {
+				expect(e.message).to.be.equal("ending the stream");
+				return;
+			}
+			throw new Error("An error should have been called");
+		});
 	}); // toArray()
 
 	describe("writeEach()", () => {


### PR DESCRIPTION
When ending a stream with an error, the resulting promise will also 
fail (be rejected) with that error:

```javascript
const stream = new Stream()
const p = stream.end(new Error('hello world'))
p.catch(err => {
   // here 'err' will contain the 'hello world' error!
})
```

This seems wrong to me as the `.end(err)` was executed properly. This PR changes that particular behavior to only fail the Promise resulting from `.end(err)` if the error cause is a different one from the passed-in error.