### PR TITLE
NodeJS adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,27 @@ sink.result().then(
 );
 ```
 
+## Working with NodeJS streams
+
+The `FileSink` class mentioned in the [Writing to a file](#writing-to-a-file) section is a specific wrapper around a NodeJS stream (`fs.createWriteStream`). There are a few more general-purpose functions available when working with NodeJS streams that you might find useful.
+
+```ts
+const source = Stream.from([1, 2, 3]);
+const dest: Express.Response = resp;
+// Pipe a ts-stream to some NodeJS stream.
+pipeToNodeStream(source, dest);
+```
+
+```ts
+// Convert a NodeJS readable stream to a ts-stream
+const source = fromNodeReadable(fs.createReadStream('test.txt'));
+// Convert a NodeJS writable stream to a ts-stream
+const dest = fromNodeWritable(fs.createWriteStream('all_caps.txt'));
+source
+  .map((chunk) => String(chunk))
+  .map((letters) => letter.toUpperCase())
+  .pipe(dest);
+```
 ## Error propagation
 
 Errors generated in `forEach()`'s read handler are 'returned' to the corresponding

--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ source
   .pipe(dest);
 ```
 
+It's worth noting that `fromNodeReadable` and `fromNodeWritable` take an optional generic type argument. It's advised that you provide the appropriate type for your NodeJS stream. For `fromNodeReadable` when no type argument is provided, the generated ts-stream will be of type `string | Buffer` (which is the type for each chunk for streams that are **not** in `objectMode`).
+
+```ts
+// Produces a ts-stream of type `Stream<string | Buffer>` (the default type).
+const a = fromNodeReadable(someNodeStreamNotInObjectMode);
+// When working with NodeJS streams in object mode you'll want to specify the type.
+// Produces a ts-stream of type `Stream<{ message: string; }>`.
+const b = fromNodeReadable<{ message: string; }>(someNodeStreamInObjectMode);
+```
+
 ## Error propagation
 
 Errors generated in `forEach()`'s read handler are 'returned' to the corresponding

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ source
   .map((letters) => letter.toUpperCase())
   .pipe(dest);
 ```
+
 ## Error propagation
 
 Errors generated in `forEach()`'s read handler are 'returned' to the corresponding

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -260,11 +260,11 @@ export function fromNodeReadable(
 /**
  * Create a ts-stream WritableStream from a Node.JS WritableStream.
  *
- * @see pipeToNodeStream for implementation details as this is a thinn wrapper.
+ * @see pipeToNodeStream for implementation details as this is a thin wrapper.
  *
  * Usage example:
  * ```ts
- * const sink = toNodeWritable(fs.createWriteStream('sink.txt'));
+ * const sink = fromNodeWritable(fs.createWriteStream('sink.txt'));
  * Stream.from(['some', 'lowercased', 'words'])
  *  .map((chunk) => String(chunk))
  *  .map((word) => word.toUpperCase())

--- a/src/test/node.ts
+++ b/src/test/node.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+import { Readable, Writable } from "stream";
+import { Stream } from "../lib/index";
+import { fromNodeWritable, fromNodeReadable } from "../lib/node";
+
+describe("node", () => {
+	describe("fromNodeReadable", () => {
+		it("it consumes data from the stream until the stream closes", async () => {
+			const nodeStream = Readable.from(
+				(async function* () {
+					yield "hi";
+					yield "bye";
+				})()
+			);
+			const result = await fromNodeReadable(nodeStream).toArray();
+			expect(result).to.have.members(["hi", "bye"]);
+		});
+
+		it("it ends the ts-stream when the node stream emits an error", async () => {
+			const errorMessage = "uh oh!";
+			const nodeStream = Readable.from(
+				(async function* () {
+					throw new Error(errorMessage);
+				})()
+			);
+
+			const result = await fromNodeReadable(nodeStream)
+				.toArray()
+				.catch((e) => e);
+
+			expect(result instanceof Error).to.equal(true);
+			expect(result.message).to.equal(errorMessage);
+		});
+
+		it("it ends the ts-stream when the node stream emits a close event", async () => {
+			const nodeStream = Readable.from(
+				(async function* () {
+					yield "hi";
+					yield "bye";
+				})()
+			);
+
+			const messages: string[] = [];
+			await fromNodeReadable(nodeStream)
+				// We expect this fn to only run once (for the first message) before the close event is emitted.
+				.forEach((message) => {
+					messages.push(String(message));
+					nodeStream.emit("close");
+				});
+
+			expect(messages.length).to.equal(1);
+			expect(messages).to.have.members(["hi"]);
+		});
+	});
+
+	describe("fromNodeWritable", () => {
+		it("consumes data from a ts-stream", async () => {
+			const messages: string[] = [];
+			const nodeStream = new Writable({
+				write: (chunk, _, cb) => {
+					messages.push(String(chunk));
+					cb(null);
+				},
+			});
+
+			await Stream.from(["hi", "bye"])
+				.pipe(fromNodeWritable(nodeStream))
+				.result();
+
+			expect(messages).to.have.members(["hi", "bye"]);
+		});
+	});
+});

--- a/src/test/node.ts
+++ b/src/test/node.ts
@@ -51,6 +51,126 @@ describe("node", () => {
 			expect(messages.length).to.equal(1);
 			expect(messages).to.have.members(["hi"]);
 		});
+
+		it("it destroys the node stream and ends the ts-stream when the ts-stream's `write` call fails", async () => {
+			const errorMessage = "write failed";
+			const nodeStream = Readable.from(
+				(async function* () {
+					while (1) {
+						yield "hi";
+					}
+				})()
+			);
+
+			const stream = fromNodeReadable(nodeStream);
+
+			let ended: Error | undefined;
+			let aborted: Error | undefined;
+			await stream
+				.forEach(
+					// simulate a failing `write` call
+					(_chunk) => Promise.reject(new Error(errorMessage)),
+					(endErr) => {
+						ended = endErr;
+					},
+					(abortErr) => {
+						aborted = abortErr;
+					}
+				)
+				.catch((e) => e);
+
+			expect(nodeStream.destroyed).to.equal(true);
+			expect(ended?.message).to.equal(errorMessage);
+			expect(aborted).to.equal(undefined);
+		});
+
+		it("it destroys the node stream and ends the ts-stream when the ts-stream's `end` call fails", async () => {
+			const errorMessage = "end failed";
+			const nodeStream = Readable.from(
+				(async function* () {
+					yield "hi";
+				})()
+			);
+
+			const stream = fromNodeReadable(nodeStream);
+
+			let aborted: Error | undefined;
+			await stream
+				.forEach(
+					(_chunk) => Promise.resolve(),
+					// simulate a failing `end` call
+					(_endErr) => Promise.reject(new Error(errorMessage)),
+					(abortErr) => {
+						aborted = abortErr;
+					}
+				)
+				.catch((e) => e);
+
+			expect(nodeStream.destroyed).to.equal(true);
+			expect(aborted).to.equal(undefined);
+		});
+
+		it("it destroys the node stream and ends the ts-stream when the ts-stream's `write` and `end` calls fail", async () => {
+			const writeErrorMessage = "write failed";
+			const endErrorMessage = "end failed";
+			const nodeStream = Readable.from(
+				(async function* () {
+					yield "hi";
+				})()
+			);
+
+			const stream = fromNodeReadable(nodeStream);
+
+			let aborted: Error | undefined;
+			await stream
+				.forEach(
+					// simulate a failing `write` call
+					(_chunk) => Promise.reject(new Error(writeErrorMessage)),
+					// simulate a failing `end` call
+					(_endErr) => Promise.reject(new Error(endErrorMessage)),
+					(abortErr) => {
+						aborted = abortErr;
+					}
+				)
+				.catch((e) => e);
+
+			expect(nodeStream.destroyed).to.equal(true);
+			expect(aborted).to.equal(undefined);
+		});
+
+		it("it destroys the node stream and ends the ts-stream when the ts-stream is aborted", async () => {
+			const errorMessage = "uh oh!";
+			const nodeStream = Readable.from(
+				(async function* () {
+					while (1) {
+						yield "hi";
+					}
+				})()
+			);
+
+			const stream = fromNodeReadable(nodeStream);
+			await stream.abort(new Error(errorMessage));
+
+			let ended: Error | undefined;
+			let aborted: Error | undefined;
+			const result = await stream
+				.forEach(
+					(_chunk) => Promise.resolve(),
+					(endErr) => {
+						ended = endErr;
+					},
+					(abortErr) => {
+						aborted = abortErr;
+					}
+				)
+				.catch((e) => e);
+
+			expect(result instanceof Error).to.equal(true);
+			expect(result.message).to.equal(errorMessage);
+			expect(nodeStream.destroyed).to.equal(true);
+			expect(ended?.message).to.equal(errorMessage);
+			expect(aborted?.message).to.equal(errorMessage);
+		});
 	});
 
 	describe("fromNodeWritable", () => {


### PR DESCRIPTION
This PR adds two general adapters to make it easier to work with node streams.

**`fromNodeReadable`**: Create a ts-stream ReadableStream from a Node.JS ReadableStream.

**`fromNodeWritable`**: Create a ts-stream WritableStream from a Node.JS WritableStream.

**May address the following issues**
https://github.com/poelstra/ts-stream/issues/17
https://github.com/poelstra/ts-stream/issues/40
https://github.com/poelstra/ts-stream/issues/46